### PR TITLE
Single event styling

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -31,7 +31,6 @@ page '/*.json', layout: false
 page '/*.txt', layout: false
 page '/', layout: "home"
 page "/events/*", layout: "events"
-page "/events/", layout: "pages"
 
 
 # Proxy pages (http://middlemanapp.com/basics/dynamic-pages/)

--- a/source/archive/_archive_block.slim
+++ b/source/archive/_archive_block.slim
@@ -10,5 +10,5 @@
         ul class="archive-#{year}"
           - events.reverse.each do |event|
             li
-              a href="/events/#{event.date}"
+              a.a-link-pill href="/events/#{event.date}"
                 = I18n.localize parse_date(event.date), format: '%d. %B', locale: 'de'

--- a/source/layouts/events.html.slim
+++ b/source/layouts/events.html.slim
@@ -11,27 +11,18 @@ html.no-js
     #wrap
       #page
         #header
-          = partial "/shared/header"
+          = partial "/shared/header-small"
         .content
-          .event-box
-            = partial "shared/content/_event_box.slim",
-              locals: {locale: 'de', next_event: next_event, upcoming_events: upcoming_events}
-          #event-data.row.large-10.large-centered
-            .back-link
-              a href="/archive"
-                =I18n.t('events.past.list', locale: 'de')
-            .event-hero
-              = partial "shared/event-structured-markup", locals: {event: current_page.data}
-            .event-details
-              = yield
+          #event-data.row
+            .small-12.large-10.large-centered.columns
+              = link_to "&larr; zurück zur Übersicht", "/archive", class: "back-link"
+              .b-event-hero
+                = partial "shared/event-structured-markup", locals: {event: current_page.data}
+              .b-event-details
+                = yield
     .row
       .b-footer.clearfix
         = partial "/shared/footer"
 
     #scripts
-      = partial "/shared/scripts", locals: { google_maps: true }
-      = javascript_include_tag "all"
-
-    #scripts
-      = partial "/shared/scripts", locals: { google_maps: false }
       = javascript_include_tag "all"

--- a/source/shared/_event-structured-markup.html.slim
+++ b/source/shared/_event-structured-markup.html.slim
@@ -1,27 +1,28 @@
 = unless event.empty?
   span { itemscope itemtype="http://schema.org/Event" }
-
+  meta { itemprop="startDate" content="#{event.startDate}"}
+  meta { itemprop="endDate" content="#{event.endDate}"}
+  
+  .small-12.colums
     span { itemprop="performer" }
-      a {itemprop="url" href="#{event.url}"}
-        h3 { itemprop="name" } = event.name
+      h3.a-page-title { itemprop="name" } 
+        = event.title + ', ' + event.startDate.to_date.strftime('%d.%m.%Y')
+  .row
+    .small-12.medium-2.columns
+      img { class="a-event-image" itemprop="image" src="/images/logo.svg" }
+    .small-12.medium-10.columns
+      .further-info
+        span { itemprop="location" itemscope itemtype="http://schema.org/Place" }
+          p { itemprop="name" } = event.location.name
+          p { itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" }
+            span { itemprop="streetAddress" } = event.location.address.streetAddress
+            br
+            span { itemprop="postalCode" } = event.location.address.postalCode
+            br
+            span { itemprop="addressLocality"} = event.location.address.addressLocality
+            br
+            span { itemprop="addressCountry" } = event.location.address.addressCountry.name
 
-    .description
-      p
-        span { itemprop="description" } =event.description
-        meta { itemprop="startDate" content="#{event.startDate}"}
-        meta { itemprop="endDate" content="#{event.endDate}"}
-
-    .further-info
-      h4 =event.title
-      span { itemprop="location" itemscope itemtype="http://schema.org/Place" }
-        p { itemprop="name" } = event.location.name
-        p { itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" }
-          span { itemprop="streetAddress" } = event.location.address.streetAddress
-          span { itemprop="postalCode" } = event.location.address.postalCode
-          span { itemprop="addressLocality"} = event.location.address.addressLocality
-          span { itemprop="addressCountry" } = event.location.address.addressCountry.name
-
-      span { itemprop="offers" itemscope itemtype="http://schema.org/Offer" }
-        a { itemprop="url" href="#{event.offers.url}" }
-        ' 19:00 until 21:00
-    img { class="event-image" itemprop="image" src="/assets/images/logo_event.png" }
+        span { itemprop="offers" itemscope itemtype="http://schema.org/Offer" }
+          a { itemprop="url" href="#{event.offers.url}" }
+          ' 19:00 until 21:00

--- a/source/stylesheets/archive.css.sass
+++ b/source/stylesheets/archive.css.sass
@@ -28,14 +28,3 @@
       display: inline-block
       text-align: center
       margin: 15px 5px
-      a
-        border: 1px solid $light-grey
-        padding: 6px 16px
-        border-radius: 16px
-        color: $light-grey
-        transition: background-color .2s ease-out
-        -moz-transition: background-color .2s ease-out
-        -webkit-transition: background-color .2s ease-out
-        -o-transition: opacity .2s ease-out
-        &:hover
-          background-color: $green

--- a/source/stylesheets/atoms/_event-image.sass
+++ b/source/stylesheets/atoms/_event-image.sass
@@ -1,0 +1,2 @@
+.a-event-image
+  margin-bottom: 20px

--- a/source/stylesheets/atoms/_link-pill.sass
+++ b/source/stylesheets/atoms/_link-pill.sass
@@ -1,0 +1,12 @@
+.a-link-pill
+  border: 1px solid $light-grey
+  padding: 6px 16px
+  border-radius: 16px
+  color: $light-grey
+  transition: background-color .2s ease-out
+  -moz-transition: background-color .2s ease-out
+  -webkit-transition: background-color .2s ease-out
+  -o-transition: opacity .2s ease-out
+  &:hover
+    background-color: $light-grey
+    color: $mirage

--- a/source/stylesheets/base/_base.sass
+++ b/source/stylesheets/base/_base.sass
@@ -5,3 +5,9 @@ body
   background-color: $light-grey
   color: $mirage
   font-size: 16px
+
+a
+  color: $green
+
+  &:hover
+    color: darken($green, 20)

--- a/source/stylesheets/blocks/_event-details.sass
+++ b/source/stylesheets/blocks/_event-details.sass
@@ -1,0 +1,15 @@
+.b-event-details
+  margin-bottom: 80px
+
+  h1
+    font-size: 31px
+
+  h2
+    font-size: 25px
+
+  +breakpoint(small only)
+    h1
+      font-size: 19px
+
+    h2
+      font-size: 18px

--- a/source/stylesheets/blocks/_event-hero.sass
+++ b/source/stylesheets/blocks/_event-hero.sass
@@ -1,0 +1,2 @@
+.b-event-hero
+  margin-bottom: 80px

--- a/source/stylesheets/style.css.sass
+++ b/source/stylesheets/style.css.sass
@@ -20,6 +20,7 @@
 @import 'atoms/person-container'
 @import 'atoms/content-box'
 @import 'atoms/page-title'
+@import 'atoms/event-image'
 
 // Blocks
 @import 'blocks/header'
@@ -30,6 +31,8 @@
 @import 'blocks/content-boxes'
 @import 'blocks/map'
 @import 'blocks/masonry'
+@import 'blocks/event-hero'
+@import 'blocks/event-details'
 @import 'blocks/footer'
 
 // Helpers

--- a/source/stylesheets/style.css.sass
+++ b/source/stylesheets/style.css.sass
@@ -21,6 +21,7 @@
 @import 'atoms/content-box'
 @import 'atoms/page-title'
 @import 'atoms/event-image'
+@import 'atoms/link-pill'
 
 // Blocks
 @import 'blocks/header'


### PR DESCRIPTION
Improves styling of single events.

Some of the markup was cleaned up, the title of an event no longer is just `Webmontag`, but the number and the date (i.e. `53. Webmontag, 20.02.2017`).  
The styling of links was adapted to the rest of the page. Also, the headlines were altered in the stylesheet to be smaller, since they don't fit the page hierarchy as they come out of the wiki.